### PR TITLE
Bugfix: can't evaluate reader.lisp while LSX syntax is enabled

### DIFF
--- a/reader.lisp
+++ b/reader.lisp
@@ -154,7 +154,8 @@
        (throw 'end-of-tag *reading-tag-children*))
 
       ;; Fallback rules
-      ((char= next #\Space) '<)
+      ((or (char= next #\Space)
+           (char= next #\)))'<)
       (t (intern (format nil "<~S" (read stream)))))))
 
 (defun do-nothing (stream char)


### PR DESCRIPTION
This has been caused by a fallback rule in `read-html-tag` which returns the symbol < when followed by a space. Since this character however is immediatly followed by a closing parenthesis it will be tried as a tag instead. This pull request adds the closing parenthesis to the condition that triggers the fallback.