### PR TITLE
Added support for self closing tags

### DIFF
--- a/reader.lisp
+++ b/reader.lisp
@@ -3,7 +3,8 @@
   (:import-from #:lsx/tag
                 #:h)
   (:import-from #:lsx/html
-                #:make-declaration-element)
+                #:make-declaration-element
+                #:void-tag-p)
   (:import-from #:named-readtables
                 #:defreadtable)
   (:export #:enable-lsx-syntax
@@ -83,17 +84,6 @@
              *reading-tag-children*)))
     (loop
       (push (read-html-tag-inner stream) *reading-tag-children*))))
-
-(defparameter *void-tag-map*
-  #.(let ((ht (make-hash-table)))
-      (loop for key in
-	    '(:area :base :br :col :hr :img :input :link :meta :param :command :keygen :source)
-	    do (setf (gethash key ht) T))
-      ht))
-
-(defun void-tag-p (name)
-  (let ((name-keyword (intern (symbol-name name) "KEYWORD")))
-    (gethash name-keyword *void-tag-map*)))
 
 (defun read-html-tag-children (stream name attrs)
   (let ((*reading-tag* name)

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -39,6 +39,11 @@
   (testing "Fragments"
     (let ((frag (eval (read-lsx-string "<><p>1</p><p>2</p></>"))))
       (ok (outputs (render-object frag t) (format NIL "<p>1</p>~%<p>2</p>~%")))))
+  (testing "Self closing tags"
+    (let ((br (eval (read-lsx-string "<div><div /></div>"))))
+      (ok (typep br 'element))
+      (ok (equal (element-name br) "div"))
+      (ok (outputs (render-object br t) "<div><div></div></div>"))))
   (testing "With attributes & children"
     (let ((a (eval (read-lsx-string "<a href=\"/hello\">Say Hello</a>"))))
       (ok (typep a 'element))


### PR DESCRIPTION
This for example allows writing the following LSX `<div><div /></div>`
which will then produce the correct HTML `<div><div></div></div>`
instead of the `<div><div></div>` it returned before.

I did have to add a new boolean to the struct which stores if the tag is an actual void-tag. This was done to keep the changes to a minimum while also not slowing down rendering with hash table lookups. Maybe replacing `self-closing` and `void-tag` with a single slot for a keyword indicating the type might be preferrable, but I thought that adding a new boolean would be less invasive.

Have a nice day,
Ben